### PR TITLE
fix(tslint): fixed result from being emitted multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These are all the available tasks within `speedy-build-tools` and can be added t
 | `clean [paths..]` | Delete files and directories |
 | `lint-html`       | Lint Html files              |
 | `lint-sass`       | Lint Sass files              |
-| `lint-ts`         | Lint Typescript files        |
+| `lint-ts`         | Lint TypeScript files        |
 ___
 
 ### Clean
@@ -103,7 +103,7 @@ By default, it will try to locate the `.stylelintrc` file in the root of your pr
 
 ___
 
-### Lint Typescript
+### Lint TypeScript
 
 ```
 speedy-build-tools lint-ts

--- a/src/lint/lint-ts/lint-ts.model.ts
+++ b/src/lint/lint-ts/lint-ts.model.ts
@@ -6,6 +6,11 @@ export interface LintTsOptions {
 	fix: boolean;
 }
 
+export interface LintTsResult {
+	failuresCount: number;
+	fixesCount?: number;
+}
+
 export type LintTsFormatters = "vso"
 	| "verbose"
 	| "prose"


### PR DESCRIPTION
- fix tslint issue which was outputting result multiple times
- simplified `LintTsResult` for the consumer (rather the full blown tslint result)
- minor renaming for `handlelintTs` => `handleLintTs`
- change Typescript to TypeScript within docs